### PR TITLE
TTL sync updates

### DIFF
--- a/neuropy/io/openephysio.py
+++ b/neuropy/io/openephysio.py
@@ -336,23 +336,37 @@ def load_ttl_events(TTLfolder, zero_timestamps=True, event_names="", sync_info=T
 
     # Get sync info
     if sync_info:
-        sync_file = TTLfolder.parents[2] / "sync_messages.txt"   # This gets you time from start of dat file
-        # sync_file = (
-        #     TTLfolder.parents[3] / "recording1/sync_messages.txt"
-        # )  # Get SR and sync frame info - this gets you absolute time from start of recording!
-        SR, record_start = parse_sync_file(sync_file)
+
+        # Get SR and sync frame info - this gets you absolute time from start of recording! Use for syncing to time of day.
+        sync_file_exp = (
+            TTLfolder.parents[3] / "recording1/sync_messages.txt"
+        )
+
+        # Gets you time from start of dat file - use for syncing to frame number in a combined .dat file.
+        sync_file_rec = TTLfolder.parents[2] / "sync_messages.txt"
+
+        SR, exp_start = parse_sync_file(sync_file_exp)
+        _, record_start = parse_sync_file(sync_file_rec)
         events["SR"] = SR
+        events["recording_start_frame"] = record_start
+        events["experiment_start_frame"] = exp_start
 
         # Zero timestamps
         if zero_timestamps:
             events["timestamps"] = events["timestamps"] - record_start
+            # events["timestamps_from_exp_start"] =
 
         # Grab start time from .xml file and keep it with events just in case
         settings_file = TTLfolder.parents[4] / get_settings_filename(TTLfolder)
+        missing_set_file = False
         try:
-            events["start_time"] = pd.to_datetime(
+            exp_start_time = pd.to_datetime(
                 XML2Dict(settings_file)["INFO"]["DATE"]
             )
+            # events["start_time"] = pd.to_datetime(
+            #     XML2Dict(settings_file)["INFO"]["DATE"]
+            # )
+
         except FileNotFoundError:
             print("Settings file: " + str(settings_file) + " NOT FOUND")
 
@@ -360,11 +374,19 @@ def load_ttl_events(TTLfolder, zero_timestamps=True, event_names="", sync_info=T
             p = re.compile(
                 "[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-2]+[0-9]+-[0-6]+[0-9]+-[0-6]+[0-9]+"
             )
-            events["start_time"] = pd.to_datetime(
+
+            exp_start_time = pd.to_datetime(
                 p.search(str(settings_file)).group(0), format="%Y-%m-%d_%H-%M-%S"
             )
+            missing_set_file = True
+            # events["start_time"] = pd.to_datetime(
+            #     p.search(str(settings_file)).group(0), format="%Y-%m-%d_%H-%M-%S"
+            # )
 
-            # Print to screen to double check!
+        events["start_time"] = (exp_start_time +
+                                pd.Timedelta((record_start - exp_start) / SR, unit="sec"))
+        # Print to screen to double-check!
+        if missing_set_file:
             print(
                 str(events["start_time"])
                 + " loaded from folder structure, be sure to double check!"


### PR DESCRIPTION
We now output both sample number in combined .dat file and datetime for each event to enable syncing via either option.