### PR TITLE
Added ability to Normalize across ratemaps

### DIFF
--- a/neuropy/plotting/ratemaps.py
+++ b/neuropy/plotting/ratemaps.py
@@ -12,6 +12,7 @@ def plot_ratemap(
     ax=None,
     pad=2,
     normalize_tuning_curve=False,
+    cross_norm=None,
     sortby=None,
     cmap="tab20b",
 ):
@@ -27,6 +28,8 @@ def plot_ratemap(
         [description], by default 2
     normalize : bool, optional
         [description], by default False
+    cross_norm : np.array, optional
+        Nx2 numpy array including xmin and xptp per neuron, by default None.
     sortby : array, optional
         [description], by default True
     cmap : str, optional
@@ -51,7 +54,14 @@ def plot_ratemap(
         ax = fig.subplot(fig.gs[0])
 
     if normalize_tuning_curve:
-        tuning_curves = mathutil.min_max_scaler(tuning_curves)
+        if isinstance(cross_norm, np.ndarray):
+            # Create xmin array and set it to be broadcastable during
+            xmin = cross_norm[:,0]
+            xptp = cross_norm[:,1] - cross_norm[:,0]
+
+            tuning_curves = mathutil.min_max_external_scaler(tuning_curves, xmin, xptp)
+        else:
+            tuning_curves = mathutil.min_max_scaler(tuning_curves)
         pad = 1
 
     if sortby is None:

--- a/neuropy/utils/mathutil.py
+++ b/neuropy/utils/mathutil.py
@@ -67,8 +67,6 @@ def min_max_scaler(x, axis=-1):
     min_val = np.min(x, axis=axis, keepdims=True)
     range_val = np.ptp(x, axis=axis, keepdims=True)
     return (x - min_val)  / np.where(range_val == 0,1,range_val)
-    #return (x - np.min(x, axis=axis, keepdims=True)) / np.ptp(
-    #    x, axis=axis, keepdims=True)
 
 
 def min_max_external_scaler(x, xmin, xptp):
@@ -86,7 +84,22 @@ def min_max_external_scaler(x, xmin, xptp):
     scaled np.array
     """
 
+    # Check to make sure xmin and xptp are broadcastable to x.
+    req_shape = (x.shape[0],1)
+    if xmin.ndim == 1 and xmin.shape[0] == x.shape[0]:
+        xmin = xmin[:,np.newaxis]
+
+    if xptp.ndim == 1 and xptp.shape[0] == x.shape[0]:
+        xptp = xptp[:,np.newaxis]
+
+    if xmin.shape != req_shape:
+        raise ValueError(f"Array with shape {xmin.shape} cannot be made broadcastable to {req_shape}.")
+
+    if xptp.shape != req_shape:
+        raise ValueError(f"Array with shape {xptp.shape} cannot be made broadcastable to {req_shape}.")
+
     return (x - xmin) / xptp
+
 
 def cdf(x, bins):
     """Returns cummulative distribution for x at bins"""


### PR DESCRIPTION
- Adds optional parameter to plot_ratemaps `cross_norm` which takes in a Nx2 np.array of min/max firing rates for each neuron across conditions.
- Adds checks in mathutil to make sure xmin and xptp are broadcastable to x.