### PR TITLE
Allow ratemap plotting to plot by firing rate rather than neuron id when conditions are met 

### DIFF
--- a/neuropy/analyses/placefields.py
+++ b/neuropy/analyses/placefields.py
@@ -358,7 +358,7 @@ class Pf1D(core.Ratemap):
                                  height_ratios=[3, 2])
 
         # Plot tuning curve
-        pfuse.plot_ratemaps(normalize_tuning_curve=True, ax=ax[0])
+        pfuse.plot_ratemaps(ax=ax[0], **kwargs)
 
         # Plot raster below
         pfuse.plot_rasters(plot_time=True, ax=ax[1])

--- a/neuropy/plotting/ratemaps.py
+++ b/neuropy/plotting/ratemaps.py
@@ -98,9 +98,16 @@ def plot_ratemap(
     if normalize_xbin:
         ax.set_xlim([0, 1])
     ax.tick_params("y", length=0)
+
+    # Set y axis as the neuron id
     ax.set_ylim([0, len(sort_ind)])
-    # if self.run_dir is not None:
-    #     ax.set_title(self.run_dir.capitalize() + " Runs only")
+
+    # Set y-axis as firing rate if cross norm is provided and normalized tuning curve is false
+    if cross_norm is not None and normalize_tuning_curve is False:
+        ax.set_ylim(cross_norm[0])
+        ax.set_yticks(np.linspace(*cross_norm[0], num=3))
+        ax.set_yticklabels([f"{v:.1f}" for v in np.linspace(*cross_norm[0], num=3)])
+        ax.tick_params("y", length=4)
 
     return ax
 


### PR DESCRIPTION
- cross normalization is enabled (Provides max and min firing rate to compare betwen conditions)
- Noramlize tuning curve is False